### PR TITLE
Update service.py

### DIFF
--- a/a4kSubtitles/service.py
+++ b/a4kSubtitles/service.py
@@ -25,6 +25,15 @@ def start(api):
         has_done_subs_check = True
         has_subtitles = False
 
+        # Check if there is an IMDB number for this video
+        # If not then this is most probably not a video played from an addon that provides the IMDB number
+        # It could also be a local video file of from youtube, a tv station or...
+        # In that case don't set the subtitle stream
+        # Maybe an option should be added to the settings of a4kSubtitles if this is wanted or not
+        IMDBNumber = core.kodi.xbmc.getInfoLabel('VideoPlayer.IMDBNumber')
+        if IMDBNumber is None or IMDBNumber == '':
+            continue
+
         preferredlang = core.kodi.get_kodi_setting('locale.subtitlelanguage')
 
         try:


### PR DESCRIPTION
only download subtitles if there is an imdb number.

When I enable "Auto search" (and "Auto download first subtitle silently) I have the effect that for my TV streams which stream with  a subtitle suddenly also show subtitles while this is disabled in that particular addon.
This is because this addon enables the subtitles while it was not searched/found via the addon providers.

So I added this test that the service should only do something with subtitles if there is an imdb id available.

This may need some finetuning, for example by adding an extra option in the addon.