### PR TITLE
Fix "missing" IMDB ID

### DIFF
--- a/a4kSubtitles/lib/kodi.py
+++ b/a4kSubtitles/lib/kodi.py
@@ -162,3 +162,18 @@ def get_int_setting(group, id=None):
 
 def get_bool_setting(group, id=None):
     return get_setting(group, id).lower() == 'true'
+
+def get_versionstring():
+    return xbmc.getInfoLabel('System.BuildVersionCode')
+
+def get_version():
+    return list(map(int, get_versionstring().split('.')))
+
+def get_version_major():
+    return get_version()[0]
+
+def get_version_minor():
+    return get_version()[1]
+
+def get_version_patch():
+    return get_version()[2]

--- a/a4kSubtitles/lib/video.py
+++ b/a4kSubtitles/lib/video.py
@@ -294,24 +294,38 @@ def __update_info_from_imdb(core, meta, pagination_token=''):
     except:
         return
 
-def __get_basic_info():
+def __get_basic_info(core):
     meta = utils.DictAsObject({})
+    
+    if core.kodi.get_version_major() >= 20: #the InfoTagVideo API was added in kodi v20
+        videoInfo = xbmc.Player().getVideoInfoTag()
 
-    meta.year = xbmc.getInfoLabel('VideoPlayer.Year')
-    meta.season = xbmc.getInfoLabel('VideoPlayer.Season')
-    meta.episode = xbmc.getInfoLabel('VideoPlayer.Episode')
-    meta.tvshow = xbmc.getInfoLabel('VideoPlayer.TVShowTitle')
+        meta.year = videoInfo.getYear()
+        meta.season = videoInfo.getSeason()
+        meta.episode = videoInfo.getEpisode()
+        meta.tvshow = videoInfo.getTVShowTitle()
+        meta.title = videoInfo.getOriginalTitle()
+        if meta.title == '':
+            meta.title = videoInfo.getTitle()
+        meta.imdb_id =  videoInfo.getUniqueID('imdb')
+        filename_and_path = videoInfo.getFilenameAndPath()
+    else:
+        meta.year = xbmc.getInfoLabel('VideoPlayer.Year')
+        meta.season = xbmc.getInfoLabel('VideoPlayer.Season')
+        meta.episode = xbmc.getInfoLabel('VideoPlayer.Episode')
+        meta.tvshow = xbmc.getInfoLabel('VideoPlayer.TVShowTitle')
+        meta.title = xbmc.getInfoLabel('VideoPlayer.OriginalTitle')
+
+        if meta.title == '':
+            meta.title = xbmc.getInfoLabel('VideoPlayer.Title')
+        
+        meta.imdb_id = xbmc.getInfoLabel('VideoPlayer.IMDBNumber')
+        filename_and_path = xbmc.getInfoLabel('Player.FilenameAndPath')
+
     meta.tvshow_year = ''
-
-    meta.title = xbmc.getInfoLabel('VideoPlayer.OriginalTitle')
-    if meta.title == '':
-        meta.title = xbmc.getInfoLabel('VideoPlayer.Title')
-
     meta.filename = __get_filename(meta.title)
     meta.filename_without_ext = meta.filename
-    meta.imdb_id = xbmc.getInfoLabel('VideoPlayer.IMDBNumber')
-
-    filename_and_path = xbmc.getInfoLabel('Player.FilenameAndPath')
+    
     if meta.imdb_id == '':
         regex_result = re.search(r'.*(tt\d{7,}).*', filename_and_path, re.IGNORECASE)
         if regex_result:
@@ -329,7 +343,7 @@ def __is_imdb_id(id: str) -> bool:
     return id.startswith(__imdb_id_prefix)
 
 def get_meta(core):
-    meta = __get_basic_info()
+    meta = __get_basic_info(core)
 
     # Depending on the used scraper, the imdb_id returned by Kodi might not actually be an IMDB ID.
     if meta.imdb_id == '' or not __is_imdb_id(meta.imdb_id):


### PR DESCRIPTION
As mentioned in https://github.com/a4k-openproject/a4kSubtitles/pull/78#issuecomment-2013165420, `xbmc.getInfoLabel('VideoPlayer.IMDBNumber')` doesn't always return an IMDB ID even when it is available. Unfortunately despite the provided workaround for this, the problem persists and the addon fails to search for subtitles for certain titles. 

I've implemented a possible fix here, replacing the calls to `xbmc.getInfoLabel` with the new `InfoTagVideo` API introduced in Kodi v20. `InfoTagVideo.getUniqueId` does seem to correctly return the IMDB ID for movies when available. 

Since it's a new addition to the API this change isn't automatically backwards compatible with v19, so I've also included a version check to maintain said backwards compatibility. I'm not sure if this is the best way to handle this or if might have overlooked anything, so please review.