### PR TITLE
Encode when read subtitle file.

### DIFF
--- a/a4kSubtitles/download.py
+++ b/a4kSubtitles/download.py
@@ -73,7 +73,7 @@ def __insert_lang_code_in_filename(core, filename, lang_code):
 
 def __postprocess(core, filepath, lang_code):
     try:
-        with open(filepath, 'rb') as f:
+        with open(filepath, 'rb', encoding=core.utils.default_encoding) as f:
             text_bytes = f.read()
 
         if core.kodi.get_bool_setting('general.use_chardet'):


### PR DESCRIPTION
This should fix an issue happens a lot to me when a4ksub open the subtitles "Arabic" actually it breaking them.