### PR TITLE
Improved auto search handling

### DIFF
--- a/a4kSubtitles/service.py
+++ b/a4kSubtitles/service.py
@@ -10,9 +10,7 @@ def start(api):
         if monitor.waitForAbort(1):
             break
 
-        player_props = core.kodi.get_kodi_player_subtitles()
-
-        if not core.kodi.get_bool_setting('general', 'auto_search') or not player_props['subtitleenabled']:
+        if not core.kodi.get_bool_setting('general', 'auto_search'):
             continue
 
         has_video = core.kodi.xbmc.Player().isPlayingVideo()
@@ -42,8 +40,9 @@ def start(api):
         preferredlang = core.kodi.parse_language(preferredlang)
 
         try:
-            def update_sub_stream(player_props, preferredlang, prefer_sdh, prefer_forced):
-                if not core.kodi.get_bool_setting('general', 'auto_select'):
+            def update_sub_stream(preferredlang, prefer_sdh, prefer_forced):
+                player_props = core.kodi.get_kodi_player_subtitles()
+                if not core.kodi.get_bool_setting('general', 'auto_select') or not player_props['subtitleenabled']:
                     return
 
                 preferredlang_code = core.utils.get_lang_id(preferredlang, core.kodi.xbmc.ISO_639_2)
@@ -117,7 +116,7 @@ def start(api):
                     core.kodi.xbmc.Player().setSubtitleStream(sub_index)
                 return True
 
-            has_subtitles = update_sub_stream(player_props, preferredlang, prefer_sdh, prefer_forced)
+            has_subtitles = update_sub_stream(preferredlang, prefer_sdh, prefer_forced)
         except Exception as e:
             core.logger.debug('Error on update_sub_stream: %s' % e)
 

--- a/a4kSubtitles/service.py
+++ b/a4kSubtitles/service.py
@@ -73,13 +73,8 @@ def start(api):
                             core.logger.debug('found SDH subtitles: %s' % subname)
                             sub_index = sub['index']
                             break
-                        if prefer_forced:
-                            if (sub['isforced'] or 'forced' in subname):
-                                core.logger.debug('found forced subtitles: %s' % subname)
-                                sub_index = sub['index']
-                                break
-                        elif not sub['isforced'] and 'forced' not in subname:
-                            core.logger.debug('found not forced subtitles: %s' % subname)
+                        if prefer_forced and (sub['isforced'] or 'forced' in subname):
+                            core.logger.debug('found forced subtitles: %s' % subname)
                             sub_index = sub['index']
                             break
 
@@ -88,7 +83,7 @@ def start(api):
                             subname = sub['name'].lower()
                             if sub['language'] != preferredlang_code:
                                 continue
-                            if sub['isdefault'] or all(s not in subname for s in ['forced', 'songs', 'commentary']):
+                            if not sub['isforced'] and all(s not in subname for s in ['forced', 'songs', 'commentary']):
                                 core.logger.debug('found default subtitles: %s' % subname)
                                 sub_index = sub['index']
                                 break


### PR DESCRIPTION
Changes:
- Auto search uses the existing 'parse_language' function to parse the 'preferredlang' value
- If Kodi's subtitle language is set to 'Forced Only' then auto search will now treat it as if 'Prefer Forced' is set in a4ksubtitles
- If Kodi's subtitle language is set to 'None' will no longer attempt auto select
- If Kodi's language is not 'Forced Only' will now attempt to pick a subtitle that isn't forced, even if the embedded forced subtitles are marked as default
- If the subtitle being set is the same as the currently enabled subtitles then it will no longer set it to prevent subtitle delay from switching