### PR TITLE
Fix: subtitle post-processing never runs (binary mode with encoding= raises)

### DIFF
--- a/a4kSubtitles/download.py
+++ b/a4kSubtitles/download.py
@@ -94,7 +94,7 @@ def __insert_lang_code_in_filename(core, filename, lang_code):
 
 def __postprocess(core, filepath, lang_code):
     try:
-        with open(filepath, 'rb', encoding=core.utils.default_encoding) as f:
+        with open(filepath, 'rb') as f:
             text_bytes = f.read()
 
         if core.kodi.get_bool_setting('general.use_chardet'):


### PR DESCRIPTION
`__postprocess` has never executed — for any subtitle, in any language.

Its first statement opens the file in binary mode *and* passes `encoding=`:

https://github.com/a4k-openproject/a4kSubtitles/blob/990b1751e9f7516db87b46886720cbc54d7fe35f/a4kSubtitles/download.py#L95-L98

That raises:

```
ValueError: binary mode doesn't take an encoding argument
```

and the entire function body is wrapped in a bare `except: pass`, so it is swallowed silently.

The result is that none of the post-processing runs: no chardet detection, no `code_pages` fallback, no cp1251/koi8-r mojibake repair, and no `cleanup_subtitles`. Every downloaded subtitle is written out exactly as received.

### Symptom

Legacy-encoded subtitles render as meaningless symbols. I hit this with Thai (CP874/TIS-620), where it looks identical to a missing font — which is what made it hard to track down.

### Verification

With only this one-line change and nothing else touched — the existing 11-entry `code_pages` map and the `confidence == 1.0 or detected_lang_code == lang_code` gate left exactly as they are — three real Thai subtitles for the same film:

| subtitle | before | after |
|---|---|---|
| `... 720p BluRay YIFY - OCR` | `UnicodeDecodeError` | 99% Thai via TIS-620 |
| `... DvdRip` | `UnicodeDecodeError` | 98% Thai via TIS-620 |
| `... WEBRip.iTunes` (already UTF-8) | 99% Thai | 99% Thai via UTF-8-SIG |

chardet reports `{'encoding': 'TIS-620', 'confidence': 0.81, 'language': 'Thai'}`, which satisfies the existing gate via the language match — so the correct encoding is selected and the file is re-encoded to UTF-8 as intended. The UTF-8 file is unaffected.

I did initially try extending `code_pages` (Thai, Central European, Baltic, CJK) before finding the real cause. That turned out to be unnecessary and actively harmful — forcing the fallback broke the UTF-8 file above — so this PR is just the one line.

Tested on Kodi 22 / Python 3.14.
