### PR TITLE
Fix: OpenSubtitles never returns European Portuguese (pt-PT) subtitles

### DIFF
--- a/a4kSubtitles/services/opensubtitles.py
+++ b/a4kSubtitles/services/opensubtitles.py
@@ -159,12 +159,12 @@ def parse_search_response(core, service_name, meta, response):
         raw_lang = result['language']
         if raw_lang.lower() in ('pt-pt', 'pt'):
             language = next(
-                (l for l in meta.languages if 'portuguese' in l.lower() and 'brazil' not in l.lower()),
+                (lang for lang in meta.languages if 'portuguese' in lang.lower() and 'brazil' not in lang.lower()),
                 'Portuguese'
             )
         else:
             language = core.utils.get_lang_id(raw_lang, core.kodi.xbmc.ENGLISH_NAME)
-    
+
         return {
             'service_name': service_name,
             'service': service.display_name,

--- a/a4kSubtitles/services/opensubtitles.py
+++ b/a4kSubtitles/services/opensubtitles.py
@@ -106,6 +106,7 @@ def build_search_requests(core, service_name, meta):
         query = '%s %s' % (meta.title, meta.year)
 
     lang_ids = core.utils.get_lang_ids(meta.languages, core.kodi.xbmc.ISO_639_1)
+    lang_ids = ['pt-PT' if lid == 'pt' else lid for lid in lang_ids]
 
     params = {
         'query': query,
@@ -155,8 +156,15 @@ def parse_search_response(core, service_name, meta, response):
             return None
 
         filename = result['files'][0]['file_name']
-        language = core.utils.get_lang_id(result['language'], core.kodi.xbmc.ENGLISH_NAME)
-
+        raw_lang = result['language']
+        if raw_lang.lower() in ('pt-pt', 'pt'):
+            language = next(
+                (l for l in meta.languages if 'portuguese' in l.lower() and 'brazil' not in l.lower()),
+                'Portuguese'
+            )
+        else:
+            language = core.utils.get_lang_id(raw_lang, core.kodi.xbmc.ENGLISH_NAME)
+    
         return {
             'service_name': service_name,
             'service': service.display_name,


### PR DESCRIPTION
## Problem

Subtitles in plain Portuguese (pt-PT) never appear in the OpenSubtitles results — regardless of whether Portuguese (Brazil) is also enabled. Brazilian Portuguese subtitles are found normally; European Portuguese never is.

## Root cause

OpenSubtitles.com treats Portuguese as a "localised" language and only accepts the 4-character regional code (`pt-PT` / `pt-BR`) in the `languages` search parameter — a bare `pt` returns **zero** results (confirmed on the OpenSubtitles.com API forum: https://forum.opensubtitles.org/viewtopic.php?f=11&t=18049).

The addon already special-cases Brazilian Portuguese in `utils.get_lang_ids()`, hardcoding it to `pt-br`, but there is no equivalent handling for plain Portuguese, which falls through to `iso639.Lang('Portuguese').pt1`, i.e. `'pt'` — exactly the value the API rejects. So the search request never asks for European Portuguese in a form the API understands.

A second, related issue on the response side: `iso639.Lang()` cannot parse regional codes like `pt-PT`/`pt-pt` (it only accepts `pt` or `por`). If a subtitle result comes back tagged `pt-PT`, `get_lang_id()` raises internally, the surrounding bare `except` swallows it, and the function returns an empty string for `language`. That value then fails the exact string match against `meta.languages` performed later in `search.py` (`__apply_language_filter` / `__apply_limit`), so even a correctly-returned pt-PT result would be silently dropped instead of shown.

## Fix

In `services/opensubtitles.py`:

1. **Request side** (`build_search_requests`): after building `lang_ids`, replace a bare `'pt'` with `'pt-PT'` before sending it to the API, so the request actually asks for European Portuguese in the format the API accepts.
2. **Response side** (`parse_search_response`): explicitly handle `pt-PT`/`pt-pt` (and `pt`) results instead of routing them through `get_lang_id()`, since that helper can't parse regional codes. The language label is looked up from `meta.languages` (rather than a hardcoded literal) to guarantee it matches the exact string Kodi passed in, so it isn't filtered out downstream by the language/limit filters in `search.py`.

## Testing

Verified locally against a clone of this repo with "Portuguese" enabled (both alone, and together with "Portuguese (Brazil)"): before the fix, no pt-PT results were ever returned; after the fix, pt-PT subtitles are returned and shown correctly in both cases.