### PR TITLE
Add .srt extension when subtitle file has an unknown extension

### DIFF
--- a/a4kSubtitles/download.py
+++ b/a4kSubtitles/download.py
@@ -160,7 +160,11 @@ def download(core, params):
 
     actions_args = params['action_args']
     lang_code = core.utils.get_lang_id(actions_args['lang'], core.kodi.xbmc.ISO_639_2)
-    filename = __insert_lang_code_in_filename(core, actions_args['filename'], lang_code)
+    filename = actions_args['filename']
+    if not any(filename.lower().endswith(ext) for ext in subtitles_exts_all):
+        # For now, we will use 'srt' to mark unknown file extensions as subtitles.
+        filename = filename + ".srt"
+    filename = __insert_lang_code_in_filename(core, filename, lang_code)
     filename = core.utils.slugify_filename(filename)
     filename = filename.strip()
     archivepath = core.os.path.join(core.utils.temp_dir, 'sub.zip')


### PR DESCRIPTION
Since one of the latest versions it happens that the downloaded subtitle file doesn't have a known extension. This especially when the subtitle is downloaded via opensubtitles.
This does not give a problem for the addon or kodi itself but people also use a4Ksubtitles to get a subtitle for a video and then use the downloaded subtitle file for their purposes and it is very enoying that the extension isn't one of the known extensions anymore. This PR checks if this is the case and if so it adds the extension .srt to the subtitle file.